### PR TITLE
Fix Scene docs shows RectangleOptions instead of SceneOptions

### DIFF
--- a/src/modules/scene/readme.md
+++ b/src/modules/scene/readme.md
@@ -16,7 +16,7 @@ scene.startLoop();
 ```
 
 
-## RectangleOptions
+## SceneOptions
 Inherit from [OffscreenCanvasOptions](../offscreen-canvas/readme.md#offscreencanvasoptions).
 
 | Name | Type | Default | Comment |


### PR DESCRIPTION
It's called SceneOptions in the [src](https://github.com/pencil-js/pencil.js/blob/master/src/modules/scene/scene.js#L18)


If you've made change to the code, be sure to validate this checklist:

 - [x] I have read the [contribution guideline](../contributing.md)
 - [na] I have minimized linting error when running `npm run lint`
 - [na] I have added tests for my code
 - [na] I have successfully ran tests with `npm test`
 - [na] I have checked that everything looks good on [drawing tests](../drawingTests/index.html)
 - [x] I am an awesome human being
