### PR TITLE
🏷️ Add typescript types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,7 @@
                 "esm": "^3.2.25",
                 "jsdoc": "^3.6.6",
                 "nyc": "^15.1.0",
+                "typescript": "^4.1.3",
                 "webpack": "^5.1.3",
                 "webpack-cli": "^4.1.0"
             },
@@ -1707,7 +1708,6 @@
             "dependencies": {
                 "anymatch": "~3.1.1",
                 "braces": "~3.0.2",
-                "fsevents": "~2.1.2",
                 "glob-parent": "~5.1.0",
                 "is-binary-path": "~2.1.0",
                 "is-glob": "~4.0.1",
@@ -2501,8 +2501,7 @@
                 "esprima": "^4.0.1",
                 "estraverse": "^4.2.0",
                 "esutils": "^2.0.2",
-                "optionator": "^0.8.1",
-                "source-map": "~0.6.1"
+                "optionator": "^0.8.1"
             },
             "bin": {
                 "escodegen": "bin/escodegen.js",
@@ -6730,6 +6729,19 @@
             "license": "MIT",
             "dependencies": {
                 "is-typedarray": "^1.0.0"
+            }
+        },
+        "node_modules/typescript": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+            "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+            "dev": true,
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=4.2.0"
             }
         },
         "node_modules/typical": {
@@ -11821,6 +11833,12 @@
             "requires": {
                 "is-typedarray": "^1.0.0"
             }
+        },
+        "typescript": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+            "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+            "dev": true
         },
         "typical": {
             "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
         "src",
         "!src/**/*.test.js"
     ],
+    "types": "dist/src/pencil.d.ts",
     "sideEffects": false,
     "unpkg": "dist/pencil.min.js",
     "jsdelivr": "dist/pencil.min.js",
@@ -20,7 +21,7 @@
         "build": "webpack --mode=production",
         "contrib": "all-contributors generate",
         "docs": "rm -rf docs/ && jsdoc -c .jsdocrc",
-        "prepublishOnly": "npm run build",
+        "prepublishOnly": "npm run build && tsc",
         "postversion": "now --prod"
     },
     "ava": {
@@ -120,6 +121,7 @@
         "esm": "^3.2.25",
         "jsdoc": "^3.6.6",
         "nyc": "^15.1.0",
+        "typescript": "^4.1.3",
         "webpack": "^5.1.3",
         "webpack-cli": "^4.1.0"
     }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "src",
         "!src/**/*.test.js"
     ],
-    "types": "dist/src/pencil.d.ts",
+    "types": "dist/index.d.ts",
     "sideEffects": false,
     "unpkg": "dist/pencil.min.js",
     "jsdelivr": "dist/pencil.min.js",
@@ -18,10 +18,10 @@
         "test": "nyc --reporter=html --reporter=text-summary ava",
         "testci": "nyc --reporter=lcovonly --reporter=text-summary ava",
         "play": "webpack --mode=development --watch",
-        "build": "webpack --mode=production",
+        "build": "webpack --mode=production && tsc",
         "contrib": "all-contributors generate",
         "docs": "rm -rf docs/ && jsdoc -c .jsdocrc",
-        "prepublishOnly": "npm run build && tsc",
+        "prepublishOnly": "npm run build",
         "postversion": "now --prod"
     },
     "ava": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  // Change this to match your project
+  "include": ["src/**/*"],
+
+  "compilerOptions": {
+    // Tells TypeScript to read JS files, as
+    // normally they are ignored as source files
+    "allowJs": true,
+    // Generate d.ts files
+    "declaration": true,
+    // This compiler run should
+    // only output d.ts files
+    "emitDeclarationOnly": true,
+    // Types should go into this directory.
+    // Removing this would place the .d.ts files
+    // next to the .js files
+    "outDir": "dist"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,19 +1,10 @@
 {
-  // Change this to match your project
-  "include": ["src/**/*"],
-
-  "compilerOptions": {
-    // Tells TypeScript to read JS files, as
-    // normally they are ignored as source files
-    "allowJs": true,
-    // Generate d.ts files
-    "declaration": true,
-    // This compiler run should
-    // only output d.ts files
-    "emitDeclarationOnly": true,
-    // Types should go into this directory.
-    // Removing this would place the .d.ts files
-    // next to the .js files
-    "outDir": "dist"
-  }
+    "include": ["./src/**/*"],
+    "exclude": ["**/*.test.js"],
+    "compilerOptions": {
+        "allowJs": true,
+        "declaration": true,
+        "emitDeclarationOnly": true,
+        "outDir": "./dist"
+    }
 }


### PR DESCRIPTION
#### Add typings in root module
 - Kind: feature
 - Related issue: #88   

#### Description 
Adds typescript as dev dependency and builds the types prior to publishing.

#### Caveats
Individual modules do not provide typings.

Please thoroughly check that the add cli script works. I hate working with cli scripts because they depend too much of your environment.